### PR TITLE
get_prep_value now handles empty strings

### DIFF
--- a/partial_date/fields.py
+++ b/partial_date/fields.py
@@ -155,8 +155,8 @@ class PartialDateField(models.Field):
         )
 
     def get_prep_value(self, value):
-        if value is None:
-            return value
+        if value in (None, ''):
+            return None
         partial_date = self.to_python(value)
         date = partial_date.date
         return datetime.datetime(date.year, date.month, date.day, second=partial_date.precision)


### PR DESCRIPTION
**What is this PR?**
Empty string date values were throwing Exceptions when attempting to parseDate in the constructor of the PartialDate class. This issue arises when the Model has a nullable (blank=True, null=True) PartialDateField. Managing this Model through Django Admin is an easy way to re-create this issue.

**What has changed?**
The check for None in get_prep_value() now also checks for an empty string and does not attempt to construct a new PartialDate object

**Testing**
Only tested manually, as it has not been possible to run the existing tests

**Improvements**
It is still possible to construct a PartialDate class with an empty string and throw an Exception. A guard could be added