### PR TITLE
Add support for Django 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Django custom model field for partial dates with the form YYYY, YYYY-MM, YYYY-MM
 
  * Works with DRF
  * Supports comparison operations
+ * Supports Django 3.0
 
 Usage
 ================
@@ -97,3 +98,4 @@ datetime.date(2015, 11, 1)
 Thanks for their collaborations to
 - lorinkoz
 - howieweiner
+- jghyllebert

--- a/partial_date/fields.py
+++ b/partial_date/fields.py
@@ -5,8 +5,8 @@ import re
 
 from django.core import  exceptions
 from django.db import models
-from django.utils import six
 from django.utils.translation import ugettext_lazy as _
+import six
 
 
 partial_date_re = re.compile(

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     packages=['partial_date'],
 
     install_requires=[
+        'six',
         'django',
     ],
 )


### PR DESCRIPTION
https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis
