### PR TITLE
Replaced import ugettext_lazy with gettext_lazy

### DIFF
--- a/partial_date/fields.py
+++ b/partial_date/fields.py
@@ -6,7 +6,7 @@ import six
 
 from django.core import exceptions
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 partial_date_re = re.compile(


### PR DESCRIPTION
ugettext_lazy was removed in Django 4.0. See: https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-4-0